### PR TITLE
imageがnullの時の対処

### DIFF
--- a/src/pages/effectors/new.tsx
+++ b/src/pages/effectors/new.tsx
@@ -35,8 +35,9 @@ const NewEffector: NextPage = () => {
   })
 
   const submitArticle = useCallback(async (value: FormValues) => {
+    console.log(value)
     let imageUrl = ''
-    if(value.image[0]) {
+    if(value.image && value.image[0]) {
       // 画像をfirebase storageへ保存
       const imagePath = `effector/${value.image[0].name}`
       await storage().ref().child(imagePath).put(value.image[0])

--- a/src/pages/effectors/new.tsx
+++ b/src/pages/effectors/new.tsx
@@ -35,7 +35,6 @@ const NewEffector: NextPage = () => {
   })
 
   const submitArticle = useCallback(async (value: FormValues) => {
-    console.log(value)
     let imageUrl = ''
     if(value.image && value.image[0]) {
       // 画像をfirebase storageへ保存


### PR DESCRIPTION
## 何が行ったか
エフェクター投稿で選択画像がない時、`value.image`自体がnullになり判定できないエラーが出ていた。